### PR TITLE
Relax Rails dependency to work on Rails 4

### DIFF
--- a/jquery-minicolors-rails.gemspec
+++ b/jquery-minicolors-rails.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |gem|
   gem.authors = ['Kostiantyn Kahanskyi']
   gem.email = %w[kostiantyn.kahanskyi@googlemail.com]
   gem.files = Dir['{app,lib,vendor}/**/*'] + %w[Rakefile README.md]
-  gem.add_dependency 'rails', '~> 3.2.8'
+  gem.add_dependency 'rails', '>= 3.2.8'
   gem.add_dependency 'jquery-rails'
 end


### PR DESCRIPTION
I'm using this gem on a Rails 4 beta project, and had to relax the dependency on gemspec in order for it to work.

It seems to work just fine otherways, with simple_form integration and all!
