### PR TITLE
Update :text to :string

### DIFF
--- a/app/inputs/minicolors_input.rb
+++ b/app/inputs/minicolors_input.rb
@@ -7,6 +7,6 @@ if defined? SimpleForm
       end
     end
 
-    def input_type; :text end
+    def input_type; :string end
   end
 end


### PR DESCRIPTION
I am getting an error from simple_form: 'Could not find method for :text' with Rails 4.0.0 and simple_form 1.4.1

Updating :text to :string resolves the issue for my instance. 

Major Caveat: Without more testing I am not sure how backwards compatible this change would be with people not yet on 4.0.0 or greater. 

Just thought I would mention this fix for my situation in case it helped you or others. 

Thanks for the gem!
David
