### PR TITLE
Remove height style for input field

### DIFF
--- a/vendor/assets/stylesheets/jquery.minicolors.css.erb
+++ b/vendor/assets/stylesheets/jquery.minicolors.css.erb
@@ -248,7 +248,6 @@
   display: inline-block;
 }
 .minicolors-theme-default .minicolors-input {
-  height: 20px;
   width: auto;
   display: inline-block;
   padding-left: 26px;


### PR DESCRIPTION
Fixing the input field height causes formatting issues - we want the input field to look 'standard', i.e. match the other input fields on the form, therefore it should not have its own style. 